### PR TITLE
fix: remove lucid-txpipe dependency from offchain

### DIFF
--- a/offchain/package.json
+++ b/offchain/package.json
@@ -31,7 +31,6 @@
     "@spacebudz/lucid": "npm:@jsr/spacebudz__lucid@^0.20.10",
     "chai": "^5.1.1",
     "dotenv": "^16.4.5",
-    "lucid-txpipe": "^0.10.13",
     "pino": "^9.1.0",
     "pino-pretty": "^11.1.0",
     "ts-node": "^10.9.2",

--- a/offchain/src/types.ts
+++ b/offchain/src/types.ts
@@ -1,5 +1,4 @@
 import { Constr, Data, fromText } from "@spacebudz/lucid";
-import { Data as DataOld } from "lucid-txpipe";
 import {
   CardanoAddressAddress,
   CardanoAddressPaymentCredential,
@@ -97,13 +96,13 @@ namespace SettingsRedeemer {
     );
 }
 
-const BadgeDatumSchema = DataOld.Object({
-  metadata: DataOld.Map(DataOld.Bytes(), DataOld.Bytes()),
-  version: DataOld.Integer()
+const BadgeDatumSchema = Data.Object({
+  metadata: Data.Map(Data.Bytes(), Data.Bytes()),
+  version: Data.Integer()
 });
 
-type BadgeDatumT = DataOld.Static<typeof BadgeDatumSchema>;
-const BadgeDatum = BadgeDatumSchema as unknown as BadgeDatumT;
+type BadgeDatumT = typeof BadgeDatumSchema;
+const BadgeDatum = BadgeDatumSchema;
 
 interface Metadata {
   name: string;


### PR DESCRIPTION
## What

Finishes the offchain library's migration from `lucid-txpipe` to `@spacebudz/lucid@^0.20.10`.

## Why

`lucid-txpipe@0.10.34` is the last version of an abandoned fork and bundles a stale Cardano serialization lib internally. On post-Plomin mainnet it throws `CostModel operation 166 out of bounds. Max is 166` when a consumer constructs a mainnet `Lucid` instance at startup. This is currently crashing the githoney backend (and therefore githoney.io).

The offchain source had already migrated almost entirely to `@spacebudz/lucid`; the only remaining `lucid-txpipe` usage was `Data as DataOld` in `src/types.ts`, used solely for the `BadgeDatumSchema`.

## Changes

- `src/types.ts`: dropped `import { Data as DataOld } from "lucid-txpipe"`. Replaced with `@spacebudz/lucid`'s `Data` API, which already provides `.Map`/`.Object`/`.Integer`/`.Bytes`. `Data.Object(...)` returns `T` directly, so `typeof BadgeDatumSchema` replaces `DataOld.Static<typeof BadgeDatumSchema>`.
- `package.json`: removed `lucid-txpipe`.

## Validation

- `npx tsc --noEmit` in the offchain package passes (only a pre-existing, unrelated `assignContributor.ts:76` overload error remains).
- `npm run build` produces `dist/index.{js,cjs}` with **zero** `lucid-txpipe` references.
- Built `dist/` declarations via `tsc --emitDeclarationOnly` (tsup `--dts` step crashes under Node 25 / TS 5.7 — unrelated env issue).

## Notes

- `dist/` and `*.tgz` are gitignored here (build artifacts); consumers rebuild/pack as needed.
- The separately-shipped `offchain-1.0.0.tgz` into the backend is rebuilt from this change in the backend PR.
